### PR TITLE
Update dependencies to fix ObsoleteLintCustomCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pluggable lint module for WordPress-Android.
 * In your build.gradle:
 ```groovy
 dependencies {
-    compile 'org.wordpress:lint:1.0.0' // use version 1.0.0
+    compile 'org.wordpress:lint:1.0.1' // use version 1.0.1
 }
 ```
 

--- a/WordPressLint/build.gradle
+++ b/WordPressLint/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 apply plugin: 'java-library'
 apply plugin: 'com.novoda.bintray-release'
 
-version = "1.0.0"
+version = "1.0.1"
 
 repositories {
     google()
@@ -20,11 +20,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.android.tools.lint:lint-api:26.0.1"
-    compileOnly "com.android.tools.lint:lint-checks:26.0.1"
-    testCompile "com.android.tools.lint:lint:26.0.1"
-    testCompile "com.android.tools.lint:lint-tests:26.0.1"
-    testCompile "com.android.tools:testutils:26.0.1"
+    compileOnly "com.android.tools.lint:lint-api:26.1.1"
+    compileOnly "com.android.tools.lint:lint-checks:26.1.1"
+    testCompile "com.android.tools.lint:lint:26.1.1"
+    testCompile "com.android.tools.lint:lint-tests:26.1.1"
+    testCompile "com.android.tools:testutils:26.1.1"
 }
 
 jar {

--- a/WordPressLint/src/main/java/org/wordpress/android/lint/WordPressIssueRegistry.java
+++ b/WordPressLint/src/main/java/org/wordpress/android/lint/WordPressIssueRegistry.java
@@ -2,6 +2,7 @@ package org.wordpress.android.lint;
 
 
 import com.android.tools.lint.client.api.IssueRegistry;
+import com.android.tools.lint.detector.api.ApiKt;
 import com.android.tools.lint.detector.api.Issue;
 
 import java.util.Arrays;
@@ -15,5 +16,10 @@ public class WordPressIssueRegistry extends IssueRegistry {
                 WordPressRtlCodeDetector.SET_PADDING,
                 WordPressRtlCodeDetector.SET_MARGIN,
                 WordPressRtlCodeDetector.GET_PADDING);
+    }
+
+    @Override
+    public int getApi() {
+        return ApiKt.CURRENT_API;
     }
 }


### PR DESCRIPTION
Fixes ObsoleteLintCustomCheck lint issue occurring in libs/apps depending on WordPress-Lint-Android.

 ```Lint found an issue registry (timber.lint.IssueRegistry) which did not specify the Lint API version it was compiled with.
This means that the lint checks are likely not compatible.
To fix this, make your lint IssueRegistry class contain
override val api: Int = com.android.tools.lint.detector.api.CURRENT_API
or from Java,
@Override public int getApi() { return com.android.tools.lint.detector.api.ApiKt.CURRENT_API; }
Applies to variants: debug
Does not apply to variants: release
Lint can be extended with "custom checks": additional checks implemented by developers and libraries to for example enforce specific API usages required by a library or a company coding style guideline.

The Lint APIs are not yet stable, so these checks may either cause a performance, degradation, or stop working, or provide wrong results.

This warning flags custom lint checks that are found to be using obsolete APIs and will need to be updated to run in the current lint environment.
It may also flag issues found to be using a newer version of the API, meaning that you need to use a newer version of lint (or Android Studio or Gradle plugin etc) to work with these checks.
To suppress this error, use the issue id "ObsoleteLintCustomCheck" as explained in the Suppressing Warnings and Errors section.
```

Note: The new version of the library has to be published into bintray as soon as this PR is merged. Please ping me so I don't forget to publish it. Thanks! 