### PR TITLE
Issue 8/update bintray gradle plugin

### DIFF
--- a/WordPressLint/build.gradle
+++ b/WordPressLint/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.1'
-        classpath 'com.novoda:bintray-release:0.5.0'
+        classpath 'com.novoda:bintray-release:0.9.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -44,7 +44,7 @@ publish {
     userOrg = 'wordpress-mobile'
     groupId = 'org.wordpress'
     uploadName = 'lint'
-    description = 'Lint module for WordPress-Android'
+    desc = 'Lint module for WordPress-Android'
     publishVersion = project.version
     licences = ['GPL-2.0']
     website = 'https://github.com/wordpress-mobile/WordPress-Lint-Android'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Fixes #8 

## Findings
The version updates described here was done to publish a new version of the lib since the readme doc had been updated to a dependency that wasn't yet live. 

## Solution
1. Updated novoda bintray plugin. 
2. Updated gradle version.
3. Changed the `description` to `desc` because the new version of the bintray plugin doesn't support `description` in the publish block anymore. 

## Testing
1. You can run the tests and make a clean build to see that there are no errors. 
( To actually test this you would need to make a new release, which isn't necessary at this point :) so we can just merge this since it's a version update.)

## Reviewing 
Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have considered adding accessibility improvements for my changes.
- [x] If it's feasible, I have added unit tests. 