### PR TITLE
Ignore injected constructor parameters

### DIFF
--- a/WordPressLint/src/test/java/org/wordpress/android/lint/MissingNullAnnotationDetectorTest.kt
+++ b/WordPressLint/src/test/java/org/wordpress/android/lint/MissingNullAnnotationDetectorTest.kt
@@ -267,7 +267,7 @@ class MissingNullAnnotationDetectorTest {
               @Inject ExampleClass(String name) {}
             }
         """).indented())
-                .issues(MissingNullAnnotationDetector.MISSING_METHOD_PARAMETER_ANNOTATION)
+                .issues(MissingNullAnnotationDetector.MISSING_CONSTRUCTOR_PARAMETER_ANNOTATION)
                 .run()
                 .expectClean()
     }


### PR DESCRIPTION
### Description

This PR fixes an issue where the detector was not ignoring constructor parameters when the constructor had the `@Inject` annotation. The first commit fixes a broken test, while the second commit fixes the implementation of the detector to ignore the injected constructors.

To test:

Run tests with the last commit reverted to see them fail (i.e. run `git reset HEAD~1 --hard` after checking out this branch). Then run tests again with the full branch (i.e. `git pull`, or `git reset origin/fix/ignore-injected-constructor-parameters`).

Alternatively:

Publish this to `mavenLocal`: `./gradlew assemble test publishToMavenLocal`, then, use the following patch in WordPress-FluxC-Android to test the changes here:

<details>
<summary>Patch to use this detector in FluxC</summary>

```diff
diff --git a/build.gradle b/build.gradle
index 39840c807..fe7a384d6 100644
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ allprojects {
                 includeVersion "com.facebook.flipper", "flipper-network-plugin", "0.51.0"
             }
         }
+        mavenLocal()
     }
 
     task checkstyle(type: Checkstyle) {
diff --git a/config/lint/lint.xml b/config/lint/lint.xml
index ddb2d9d6f..c42e756a9 100644
--- a/config/lint/lint.xml
+++ b/config/lint/lint.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
+    <!-- CORRECTNESS -->
+    <issue id="MissingNullAnnotationOnField">
+        <ignore path="**/generated/**" />
+    </issue>
+    <issue id="MissingNullAnnotationOnConstructorParameter">
+        <ignore path="**/generated/**" />
+    </issue>
+    <issue id="MissingNullAnnotationOnMethodParameter">
+        <ignore path="**/generated/**" />
+    </issue>
+    <issue id="MissingNullAnnotationOnMethodReturnType">
+        <ignore path="**/generated/**" />
+    </issue>
     <!-- INTEROPERABILITY -->
     <issue id="UnknownNullness" severity="informational"/>
 </lint>
diff --git a/example/build.gradle b/example/build.gradle
index c57710ae6..755fa3b8f 100644
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -164,6 +164,8 @@ dependencies {
     // Coroutines
     implementation sharedLibs.kotlinx.coroutines.core
     implementation sharedLibs.kotlinx.coroutines.android
+
+    lintChecks "org.wordpress:lint:2.0.0"
 }
 
 def loadPropertiesOrUseExampleProperties(fileName, warningDetail) {
diff --git a/fluxc/build.gradle b/fluxc/build.gradle
index 9c424cc0f..971dc6c47 100644
--- a/fluxc/build.gradle
+++ b/fluxc/build.gradle
@@ -130,6 +130,8 @@ dependencies {
     testImplementation sharedLibs.mockito.kotlin
     testImplementation sharedLibs.mockito.inline
     testImplementation sharedLibs.assertj.core
+
+    lintChecks "org.wordpress:lint:2.0.0"
 }
 
 project.afterEvaluate {
diff --git a/plugins/woocommerce/build.gradle b/plugins/woocommerce/build.gradle
index 3e243604f..57ba5e716 100644
--- a/plugins/woocommerce/build.gradle
+++ b/plugins/woocommerce/build.gradle
@@ -100,6 +100,8 @@ dependencies {
     androidTestImplementation sharedLibs.androidx.test.runner
     androidTestImplementation sharedLibs.androidx.test.ext.junit
     androidTestImplementation sharedLibs.assertj.core
+
+    lintChecks "org.wordpress:lint:2.0.0"
 }
 
 project.afterEvaluate {
```
</details>

And navigate to [this line](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/7a56411d95316e8c26015b31c5dd97c33a110f90/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpcom/taxonomy/TaxonomyRestClient.java#L40) within Android Studio to make sure the informational reporting is not flagging this constructor for the missing nullness annotations.