### PR TITLE
[Other] Various Minor Improvements

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,14 @@ steps:
   # Wait for Gradle Wrapper to be validated before running any other jobs
   - wait
 
+  - label: "Lint"
+    key: "lint"
+    plugins: *common_plugins
+    command: |
+      ./gradlew lint
+    artifact_paths:
+      - "**/build/reports/lint-results.*"
+
   - label: "Publish to S3"
     plugins: *common_plugins
     command: |

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,9 @@ steps:
       ./gradlew test
 
   - label: "Publish to S3"
+    depends_on:
+      - "lint"
+      - "test"
     plugins: *common_plugins
     command: |
       ./gradlew \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,12 @@ steps:
     artifact_paths:
       - "**/build/reports/lint-results.*"
 
+  - label: "Test"
+    key: "test"
+    plugins: *common_plugins
+    command: |
+      ./gradlew test
+
   - label: "Publish to S3"
     plugins: *common_plugins
     command: |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pluggable lint module for WordPress-Android.
 * In your build.gradle:
 ```groovy
 dependencies {
-    compile 'org.wordpress:lint:1.0.2' // use version 1.0.2
+    lintChecks 'org.wordpress:lint:2.0.0' // use version 2.0.0
 }
 ```
 

--- a/WordPressLint/src/test/java/org/wordpress/android/lint/Utils.kt
+++ b/WordPressLint/src/test/java/org/wordpress/android/lint/Utils.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier")
+
 package org.wordpress.android.lint
 
 import com.android.tools.lint.checks.infrastructure.TestFile

--- a/build.gradle
+++ b/build.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 ext {
-    lintVersion = '31.1.0'
+    lintVersion = '31.1.2'
 }


### PR DESCRIPTION
This PR adds various minor improvements to this repo, like updating `Lint` to ` 31.1.2`, adding the `Lint` check and `Test` step on the CI pipeline and having the `Publish to S3` step depending on them, updating the documentation on how to use the library, etc.

-----

Analysis List:
1. [Update lint version to 31.1.2](https://github.com/wordpress-mobile/WordPress-Lint-Android/commit/518d51181056ffb2baefa020388f82c1659405f0)

CI List:
1. [Add lint check step to pipeline](https://github.com/wordpress-mobile/WordPress-Lint-Android/commit/a9524a820f5bc0c06e069e87772adede1edf4606)
2. [Add test step to pipeline](https://github.com/wordpress-mobile/WordPress-Lint-Android/commit/f822a456d5565e6f4266a3461ba253c24d9e4bcd)
3. [Configure publish-to-s3 step to depend on lint and test](https://github.com/wordpress-mobile/WordPress-Lint-Android/commit/d754df1fb46de0066c7ec39eb577ace8e4acf007)

Test List:
1. [Suppress redundant visibility modifier on utils](https://github.com/wordpress-mobile/WordPress-Lint-Android/commit/4274774ecf7a4ce7338159d5db4cf8df75699c47)

Documentation List:
1. [Update documentation on using the library in your project](https://github.com/wordpress-mobile/WordPress-Lint-Android/commit/5d5bc9be8d0014bafef8e2ac7870d289e0d0eddf)

-----

## To test:

1. There is nothing much to test here.
2. Verifying that all the CI checks are successful should be enough.
3. However, if you want to be thorough about reviewing this change, you could build and publish the project locally (using `./gradlew publishToMavenLocal`), just to verify that it works as expected with this new `Lint` version update (`31.1.2`).