### PR TITLE
Ignore enums in null annotation detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pluggable lint module for WordPress-Android.
 * In your build.gradle:
 ```groovy
 dependencies {
-    lintChecks 'org.wordpress:lint:2.0.0' // use version 2.0.0
+    lintChecks 'org.wordpress:lint:2.1.0' // use version 2.1.0
 }
 ```
 

--- a/WordPressLint/src/test/java/org/wordpress/android/lint/MissingNullAnnotationDetectorTest.kt
+++ b/WordPressLint/src/test/java/org/wordpress/android/lint/MissingNullAnnotationDetectorTest.kt
@@ -271,4 +271,24 @@ class MissingNullAnnotationDetectorTest {
                 .run()
                 .expectClean()
     }
+    @Test
+    fun `it ignores enums`() {
+        lint().files(LintDetectorTest.java("""
+            package test;
+            
+            public enum TrafficLightState {
+                RED,
+                YELLOW,
+                GREEN
+            }
+        """).indented())
+                .issues(
+                        MissingNullAnnotationDetector.MISSING_FIELD_ANNOTATION,
+                        MissingNullAnnotationDetector.MISSING_CONSTRUCTOR_PARAMETER_ANNOTATION,
+                        MissingNullAnnotationDetector.MISSING_METHOD_PARAMETER_ANNOTATION,
+                        MissingNullAnnotationDetector.MISSING_METHOD_RETURN_TYPE_ANNOTATION
+                )
+                .run()
+                .expectClean()
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Lint-Android/issues/16

### Description

This PR fixes false positives for missing null annotations in enums. The generated UAST included methods which are not part of the real source (`values` and `valueOf`). This works by ignoring UMethods and UParameters contained within UMethods that have a null uastBody (which is the case in these instances).

#### Testing

To test, run the provided unit tests.

Optionally: Use this detector in a project (e.g. WordPress-Android). See related PR: https://github.com/wordpress-mobile/WordPress-Android/pull/20447