### PR TITLE
Report once for method or constructor parameters that has no null annotation

### DIFF
--- a/WordPressLint/src/main/java/org/wordpress/android/lint/MissingNullAnnotationDetector.kt
+++ b/WordPressLint/src/main/java/org/wordpress/android/lint/MissingNullAnnotationDetector.kt
@@ -49,21 +49,17 @@ class MissingNullAnnotationDetector : Detector(), SourceCodeScanner {
                 }
 
                 if (!node.isInjected) {
-                    node.uastParameters.forEach { visitParameter(node, it) }
+                    if (node.uastParameters.any { it.requiresNullAnnotation && !it.isNullAnnotated }) {
+                        if (node.isConstructor) {
+                            report(node, MISSING_CONSTRUCTOR_PARAMETER_ANNOTATION)
+                        } else {
+                            report(node, MISSING_METHOD_PARAMETER_ANNOTATION)
+                        }
+                    }
                 }
 
                 if (node.requiresNullAnnotation && !node.isNullAnnotated) {
                     report(node, MISSING_METHOD_RETURN_TYPE_ANNOTATION)
-                }
-            }
-
-            private fun visitParameter(node: UMethod, parameter: UParameter) {
-                if (parameter.requiresNullAnnotation && !parameter.isNullAnnotated) {
-                    if (node.isConstructor) {
-                        report(parameter, MISSING_CONSTRUCTOR_PARAMETER_ANNOTATION)
-                    } else {
-                        report(parameter, MISSING_METHOD_PARAMETER_ANNOTATION)
-                    }
                 }
             }
         }

--- a/WordPressLint/src/test/java/org/wordpress/android/lint/MissingNullAnnotationDetectorTest.kt
+++ b/WordPressLint/src/test/java/org/wordpress/android/lint/MissingNullAnnotationDetectorTest.kt
@@ -159,8 +159,8 @@ class MissingNullAnnotationDetectorTest {
                 .expectCount(1, Severity.INFORMATIONAL)
                 .expect("""
                     src/test/ExampleClass.java:4: Information: Missing null annotation [MissingNullAnnotationOnMethodParameter]
-                      String getMessage(String name) {
-                                        ~~~~~~~~~~~
+                      String getMessage(String name, String title) {
+                             ~~~~~~~~~~
                     0 errors, 0 warnings
                             """
                         .trimIndent()
@@ -220,8 +220,8 @@ class MissingNullAnnotationDetectorTest {
                 .expectCount(1, Severity.INFORMATIONAL)
                 .expect("""
                     src/test/ExampleClass.java:4: Information: Missing null annotation [MissingNullAnnotationOnConstructorParameter]
-                      ExampleClass(String name) {}
-                                   ~~~~~~~~~~~
+                      ExampleClass(String name, String title) {}
+                      ~~~~~~~~~~~~
                     0 errors, 0 warnings
                             """
                         .trimIndent()

--- a/WordPressLint/src/test/java/org/wordpress/android/lint/MissingNullAnnotationDetectorTest.kt
+++ b/WordPressLint/src/test/java/org/wordpress/android/lint/MissingNullAnnotationDetectorTest.kt
@@ -2,6 +2,7 @@ package org.wordpress.android.lint
 
 import com.android.tools.lint.checks.infrastructure.LintDetectorTest
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.detector.api.Severity
 import org.junit.Test
 import org.wordpress.android.lint.Utils.nonNullClass
 import org.wordpress.android.lint.Utils.nullableClass
@@ -148,13 +149,14 @@ class MissingNullAnnotationDetectorTest {
             package test;
 
             class ExampleClass {
-              String getMessage(String name) {
+              String getMessage(String name, String title) {
                 return name + " example";
               }
             }
         """).indented())
                 .issues(MissingNullAnnotationDetector.MISSING_METHOD_PARAMETER_ANNOTATION)
                 .run()
+                .expectCount(1, Severity.INFORMATIONAL)
                 .expect("""
                     src/test/ExampleClass.java:4: Information: Missing null annotation [MissingNullAnnotationOnMethodParameter]
                       String getMessage(String name) {
@@ -210,11 +212,12 @@ class MissingNullAnnotationDetectorTest {
             package test;
 
             class ExampleClass {
-              ExampleClass(String name) {}
+              ExampleClass(String name, String title) {}
             }
         """).indented())
                 .issues(MissingNullAnnotationDetector.MISSING_CONSTRUCTOR_PARAMETER_ANNOTATION)
                 .run()
+                .expectCount(1, Severity.INFORMATIONAL)
                 .expect("""
                     src/test/ExampleClass.java:4: Information: Missing null annotation [MissingNullAnnotationOnConstructorParameter]
                       ExampleClass(String name) {}


### PR DESCRIPTION
### Description

Report a lint issue whenever a method or a constructor has **any** parameter without no nullability annotation.

It replaces the previous behavior of reporting a separate issue for **each** parameter that has no nullability annotation.

Reasoning is to minimize the number of reports we do.